### PR TITLE
Fix Godot complaining about res://Camera.gd missing

### DIFF
--- a/start/01-Custom Camera in Godot 1-Transform the Canvas/Game.tscn
+++ b/start/01-Custom Camera in Godot 1-Transform the Canvas/Game.tscn
@@ -1,19 +1,14 @@
-[gd_scene load_steps=4 format=1]
+[gd_scene load_steps=3 format=1]
 
-[ext_resource path="res://Camera.gd" type="Script" id=1]
-[ext_resource path="res://Level.tscn" type="PackedScene" id=2]
-[ext_resource path="res://Player.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Level.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Player.tscn" type="PackedScene" id=2]
 
 [node name="View" type="Node2D"]
 
-script/script = ExtResource( 1 )
+[node name="Level" parent="." instance=ExtResource( 1 )]
 
-[node name="Level" parent="." instance=ExtResource( 2 )]
-
-[node name="Player" parent="." instance=ExtResource( 3 )]
+[node name="Player" parent="." instance=ExtResource( 2 )]
 
 transform/pos = Vector2( 690, 434 )
-
-[connection signal="move" from="Player" to="." method="update_camera"]
 
 


### PR DESCRIPTION
Someone thought Godot wouldn't complain if they just deleted Camera.gd, didn't they?

This was done simply by saving the main scene after telling it to open anyways when it found missing dependencies, in case you're wondering. This also removes the `move` signal that's defined in the scene, as that wasn't defined in the scripts yet. :)

(More of these will come if I see any issues that I know aren't supposed to be there.)