### PR TITLE
Attempt to make project naming consistent with folder names

### DIFF
--- a/final/01-Custom camera/engine.cfg
+++ b/final/01-Custom camera/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="01-Custom Camera"
+name="Custom Camera in Godot"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/final/02-Custom camera with instant room transitions/engine.cfg
+++ b/final/02-Custom camera with instant room transitions/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="02-Zelda like room transitions"
+name="Custom Camera in Godot: Zelda like room transitions"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/final/03-Camera room transitions with steering/engine.cfg
+++ b/final/03-Camera room transitions with steering/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="03-Camera room transitions with steering"
+name="Camera room transitions with steering"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/final/04-Camera with proper Object Oriented design by Lars Kokhemor/engine.cfg
+++ b/final/04-Camera with proper Object Oriented design by Lars Kokhemor/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="02-Zelda like room transitions"
+name="Custom Camera in Godot: Object-Oriented design by Lars Kekhemor"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/01-Custom Camera in Godot 1-Transform the Canvas/engine.cfg
+++ b/start/01-Custom Camera in Godot 1-Transform the Canvas/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="01-Custom Camera"
+name="Custom Camera in Godot 1: Transforming the Canvas"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/02-Custom Camera in Godot 2-Follow the Player/engine.cfg
+++ b/start/02-Custom Camera in Godot 2-Follow the Player/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="01-Custom Camera"
+name="Custom Camera in Godot 2: Follow the Player"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/03-Custom Camera in Godot 3-Let's simplify the code!/engine.cfg
+++ b/start/03-Custom Camera in Godot 3-Let's simplify the code!/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="01-Custom Camera"
+name="Custom Camera in Godot 3: Let's simplify the code!"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/04-Custom camera with instant room transitions/engine.cfg
+++ b/start/04-Custom camera with instant room transitions/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="02-Zelda like room transitions"
+name="Custom Camera in Godot 4: Zelda like room transitions"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/05-How to create a tileset/engine.cfg
+++ b/start/05-How to create a tileset/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="05-How to create a tileset"
+name="How to create a tileset"
 main_scene="res://Player.tscn"
 icon="res://icon.png"
 

--- a/start/07-Top-down character movement/engine.cfg
+++ b/start/07-Top-down character movement/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="Grid: Simple Top-down movement"
+name="Grid 1: Simple Top-down movement"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/08-Basic grid system/engine.cfg
+++ b/start/08-Basic grid system/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="Grid: Basic grid system"
+name="Grid 2: Basic grid system"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/09-Adding the last 2 methods to the Grid/engine.cfg
+++ b/start/09-Adding the last 2 methods to the Grid/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="Grid: Basic grid system"
+name="Grid 3: The last two methods"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 

--- a/start/10-Connecting the Player with the Grid/engine.cfg
+++ b/start/10-Connecting the Player with the Grid/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="Grid: Basic grid system"
+name="Grid 4: Connecting the Player"
 main_scene="res://Game.tscn"
 icon="res://icon.png"
 


### PR DESCRIPTION
This isn't really fixing any mistakes. The inconsistent naming scheme was simply bothering me a bit, and I realized that having different names for them all (even within the same topic) would help users navigate their project lists a bit faster. Also this was weird to do, because I was unsure what was intentional by you and what wasn't.

In the `start` folder, this is intended to make it a bit easier for people to understand which tutorial folder is which, in a given type of tutorial. For example, the Grid tutorials are now labeled 1 through 4 (to stay consistent with their icons) and the subtitles are slightly changed to better suit what you'll be doing with that project.

In the `final` folder, they've been changed to better suit the names of the topics they're based on.

I'm unsure if this is something that is needed, however I feel it makes everything a little more cleaner. Please excuse me if this just comes off as nit-picky. (In case you want to edit the names yourself in the future, the `engine.cfg` file is your friend :D)

P.s. I considered editing the icons of the Custom Camera projects to match the icons used in your video thumbnails, however I wasn't able to find all the icons I needed, so I'm leaving it alone for now.