### PR TITLE
Possible improvement for grid visualizer

### DIFF
--- a/final/06-Grid-based movement/GridVisualizer.gd
+++ b/final/06-Grid-based movement/GridVisualizer.gd
@@ -12,9 +12,9 @@ func _draw():
 
 	for x in range(grid.grid_size.x + 1):
 		var col_pos = x * grid.tile_size.x
-		var limit = min(window_size.y, grid.grid_size.x * grid.tile_size.x)
+		var limit = grid.grid_size.y * grid.tile_size.y
 		draw_line(Vector2(col_pos, 0), Vector2(col_pos, limit), LINE_COLOR, LINE_WIDTH)
 	for y in range(grid.grid_size.y + 1):
 		var row_pos = y * grid.tile_size.y
-		var limit = min(window_size.x, grid.grid_size.y * grid.tile_size.y)
+		var limit = grid.grid_size.x * grid.tile_size.x
 		draw_line(Vector2(0, row_pos), Vector2(limit, row_pos), LINE_COLOR, LINE_WIDTH)


### PR DESCRIPTION
Following [this video (Create the Grid's Foundation ... 2/4)](https://www.youtube.com/watch?v=Yus8zAculWA&index=12&list=PLhqJJNjsQ7KEr_YlibZ3SBuzfw9xwGduK) a GridVisualizer is used.
I tried adding a Camera2D to the Player node in order to see the whole grid, and  this is what I see:

![peek 2017-09-29 22-38](https://user-images.githubusercontent.com/6860637/31035101-03c9fa1a-a567-11e7-8179-bd7cd3583a25.gif)

---

This PR should fix the issue: 
![peek 2017-09-29 22-41](https://user-images.githubusercontent.com/6860637/31035198-6aa2a9da-a567-11e7-96a7-e65a04f377aa.gif)

I tested also with different x and y tiles count.

*Note*: I didn't see all the videos so I don't know if the GridVisualizer has been already fixed.