### PR TITLE
Improvement for "field of view" tutorial

### DIFF
--- a/start/11-Field of view with the dot product/Object.gd
+++ b/start/11-Field of view with the dot product/Object.gd
@@ -3,9 +3,13 @@ extends Node2D
 var pos = Vector2()
 var direction_from_player = Vector2()
 var direction = Vector2()
+onready var Player = get_tree().get_root().get_node("./Game/Player")
 
-func _ready():
-	var Player = get_tree().get_root().get_node("./Game/Player")
+func _ready():	
 	direction_from_player = (get_pos() - Player.get_pos()).normalized()
 	direction = direction_from_player
+	set_process(true)
+
+func _process(delta):
 	pos = get_pos()
+	direction_from_player = (get_pos() - Player.get_pos()).normalized()


### PR DESCRIPTION
In the video [[...] How to code a Field of View in Godot](https://youtu.be/dC4-TSFv32Y)
a field of view mechianic is implemented.  

I added movement to the player and discovered this strange behaviour:

![old_fov](https://user-images.githubusercontent.com/6860637/31690956-9c3d56da-b394-11e7-9514-f28a25ab0b00.gif)

---

This happens because `direction_from_player` gets assigned only once in the `_ready()` function of every Object node.  
Calculating this value in the game loop fixes this behaviour:
![fixed_fov](https://user-images.githubusercontent.com/6860637/31690957-9e790eb2-b394-11e7-8594-4d8351b6ed91.gif)


