### PR TITLE
astar_connect_walkable_cells_diagonal function

### DIFF
--- a/2018/03-30-astar-pathfinding/pathfind_astar.gd
+++ b/2018/03-30-astar-pathfinding/pathfind_astar.gd
@@ -100,7 +100,7 @@ func astar_connect_walkable_cells_diagonal(points_array):
 					continue
 				if not astar_node.has_point(point_relative_index):
 					continue
-				astar_node.connect_points(point_index, point_relative_index, true)
+				astar_node.connect_points(point_index, point_relative_index, false)
 
 
 func is_outside_map_bounds(point):


### PR DESCRIPTION
When connecting the points (astar_node.connect_points(point_index, point_relative_index, true)), the last parameter should be false. If bidirectional is true, the connections will be double, every point will have two exact connections to the other points.

**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
A function parameter change


**Does this PR introduce a breaking change?**
No


## New feature or change ##
I changed the last parameter of astar_node.connect_points of the astar_connect_walkable_cells_diagonal function to false

**What is the current behavior?** 
Every point have two exact connections with each of the near points


**What is the new behavior?**
Every point have one connection with each of the near points


**Other information**
